### PR TITLE
Changes to support Singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN mkdir -p /etc/vomses \
 
 COPY etc/rucio/rucio.cfg.*.j2 / 
 COPY etc/bashrc /root/.bashrc
+COPY etc/rucio_cli.sh /etc/profile.d
+
 
 # create non-priveleged dummy user
 RUN useradd -ms /bin/bash user

--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ $ docker run -e RUCIO_CFG_ACCOUNT=<myrucioaccount> -v /path/to/rucio.cfg:/opt/ru
 ```bash
 $ docker run -e RUCIO_CFG_ACCOUNT=<myrucioaccount> -e RUCIO_CFG_AUTH_TYPE=userpass -e RUCIO_CFG_USERNAME=<myrucioname> -e RUCIO_CFG_PASSWORD=<myruciopassword> -it --name=rucio-client rucio-client
 ```
+
+## Run in Singularity
+First create a local Singularity image:
+```
+singularity build rucio-cli.simg docker://projectescape/rucio-client:latest
+```
+
+and then execute it from there:
+```
+mkdir -p ${HOME}/.rucio
+export RUCIO_CFG_ACCOUNT=<my_account>
+singularity run -B ${HOME}/.rucio/:/opt/rucio/etc -B ${HOME}/.globus/client.crt:/opt/rucio/etc/client.crt -B ${HOME}/.globus/client.key:/opt/rucio/etc/client.key rucio-cli.simg
+```
+If for any reason, you need to initialise with a clean configuration file, you can delete ${HOME}/.rucio/rucio.cfg. 

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -7,7 +7,7 @@ shopt -s checkwinsize
 if [ ! -f /opt/rucio/etc/rucio.cfg ]; then
     echo "File rucio.cfg not found. It will generate one."
     mkdir -p /opt/rucio/etc/
-    j2 rucio.cfg.escape.j2 > /opt/rucio/etc/rucio.cfg
+    j2 /rucio.cfg.escape.j2 > /opt/rucio/etc/rucio.cfg
 fi
 
 echo "Enable shell completion on the rucio commands"

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -1,17 +1,8 @@
 #!/bin/sh
-# Authors:
-# - Vincent Garonne, <vgaronne@gmail.com>, 2018
 
-shopt -s checkwinsize
-
-if [ ! -f /opt/rucio/etc/rucio.cfg ]; then
-    echo "File rucio.cfg not found. It will generate one."
-    mkdir -p /opt/rucio/etc/
-    j2 /rucio.cfg.escape.j2 > /opt/rucio/etc/rucio.cfg
-fi
-
-echo "Enable shell completion on the rucio commands"
-eval "$(register-python-argcomplete rucio)"
-eval "$(register-python-argcomplete rucio-admin)"
+# Making user owner of rucio/etc so that we can run the init
+# as user, making it easier to port to Singularity
+mkdir -p /opt/rucio/etc/
+chown -R user:user /opt/rucio/etc/
 
 su - user; exit

--- a/etc/rucio_cli.sh
+++ b/etc/rucio_cli.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2018
+# Adapted by Yan Grange, <grange@astron.nl>, 2020
+
+shopt -s checkwinsize
+
+if [ ! -f /opt/rucio/etc/rucio.cfg ]; then
+    echo "File rucio.cfg not found. It will generate one."
+    j2 /rucio.cfg.escape.j2 > /opt/rucio/etc/rucio.cfg
+fi
+
+echo "Enable shell completion on the rucio commands"
+eval "$(register-python-argcomplete rucio)"
+eval "$(register-python-argcomplete rucio-admin)"


### PR DESCRIPTION
As I mentioned in my comment on issue EDLK-37, I had a stab at getting the container to work under Singularity. The main issue I encountered was that the configuration of Rucio is written at run time by root. So I propose a few changes in the desing, which basically make the directory /opt/root/etc owned by user. Then in Singularity, this directory can be an external bind. 

The execution instruction for Docker does not change. For Singularity it will be:
```
expert RUCIO_CFG_ACCOUNT=<my_account>
mkdir -p ${HOME}/.rucio/
singularity run -B ${HOME}/.rucio/:/opt/rucio/etc -B ${HOME}/.globus/client.crt:/opt/rucio/etc/client.crt -B ${HOME}/.globus/client.key:/opt/rucio/etc/client.key docker://projectescape/rucio-client:latest
```

A bit more in line with the current documentation could be to actually first build the Singularity image:
```
singularity build rucio-cli.simg docker://projectescape/rucio-client:latest
```
and then execute it from there:
```
export RUCIO_CFG_ACCOUNT=<my_account>
ingularity run -B ${HOME}/.rucio/:/opt/rucio/etc -B ${HOME}/.globus/client.crt:/opt/rucio/etc/client.crt -B ${HOME}/.globus/client.key:/opt/rucio/etc/client.key rucio-cli.simg
```

This also means the config file is written outside the container, which would probably need to be mentioned (as opposed to Docker where it is basically generated at each run). Especially projects that use shared accounts may encounter some issues here (which are pretty easy to solve, as long as you know). 

For testing: the syntax is a bit different if you want to use a local Docker container:
```
singularity run <flags> docker-daemon:rucio-testing
```
(similarly for build)