### PR TITLE
Fix CA path for current version to work

### DIFF
--- a/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
+++ b/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
@@ -4,7 +4,7 @@
 [client]
 rucio_host = {{ RUCIO_CFG_RUCIO_HOST | default('https://escape-rucio.cern.ch:32300/') }}
 auth_host = {{ RUCIO_CFG_AUTH_HOST | default('https://escape-rucio.cern.ch:32301/') }}
-ca_cert = {{ RUCIO_CFG_CA_CERT | default('/etc/pki/tls/certs/ca-bundle.crt') }}
+ca_cert = {{ RUCIO_CFG_CA_CERT | default('/etc/grid-security/certificates/CERN-Root-2.pem') }}
 auth_type = {{ RUCIO_CFG_AUTH_TYPE | default('x509') }}
 username = {{ RUCIO_CFG_USERNAME | default('') }}
 password = {{ RUCIO_CFG_PASSWORD | default('') }}


### PR DESCRIPTION
From email (from @riccardodimaria ): 

> The culprit is a cert.
> Please try with the following and let me know. 

> - Change the ca_cert in the rucio.cfg to `/etc/grid-security/certificates/CERN-Root-2.pem`

> If this work for you, please update GitHub and upload a new image in dockerfile as latest. 