### PR TITLE
RUCIO CLI authocompletion is activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Rucio-Client-Containers
+
+A few things have been modified compared the master branch:
+
+1_ The Docker file of the rucio-jupyterhub-container was modified to activate the RUCIO autocompletion CLI. Also, the createProxyFromP12.sh file is executable inside the container.
+
+2_ The path of the .crt and .key file were changed to /home/jovyan/ in the the createProxyFromP12.sh and the rucio.cfg.j2.

--- a/rucio-jupyterhub-container/Dockerfile
+++ b/rucio-jupyterhub-container/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -q -O - \
     https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3 \
     | apt-key add -
 
-RUN echo "deb http://repository.egi.eu/sw/production/cas/1/current egi-igtf core" >> /etc/apt/sources.list 
+RUN echo "deb http://repository.egi.eu/sw/production/cas/1/current egi-igtf core" >> /etc/apt/sources.list
 
 RUN apt-get update -y && apt-get install -y ca-certificates ca-policy-egi-core && \
     apt-get clean && \
@@ -21,17 +21,19 @@ RUN mkdir -p /etc/vomses \
 RUN mkdir -p /etc/grid-security/vomsdir/escape \
     && wget https://indigo-iam.github.io/escape-docs/voms-config/voms-escape.cloud.cnaf.infn.it.lsc -O /etc/grid-security/vomsdir/escape/voms-escape.cloud.cnaf.infn.it.lsc
 
-ADD etc/init.sh /
-RUN chmod o+x /init.sh
-
-
 RUN conda install j2cli && \
     conda clean --all -f -y
 
-ADD etc/rucio.cfg.j2 /
-RUN mkdir -p /opt/rucio/etc/
-RUN fix-permissions /opt/rucio/etc/
-ADD etc/createProxyFromP12.sh /opt/rucio/etc/
+RUN mkdir -p /opt/rucio/etc/ && \
+    fix-permissions /opt/rucio/etc/
+
+ADD etc/* /
+
+RUN chmod o+x /init.sh && \
+    chmod o+x /createProxyFromP12.sh
+
+RUN echo 'eval "$(register-python-argcomplete rucio)"' >> ~/.bashrc
+RUN echo 'eval "$(register-python-argcomplete rucio-admin)"' >> ~/.bashrc
 
 USER $NB_UID
 CMD /init.sh

--- a/rucio-jupyterhub-container/etc/createProxyFromP12.sh
+++ b/rucio-jupyterhub-container/etc/createProxyFromP12.sh
@@ -3,14 +3,15 @@
 # If cert, key files and rucio.cfg has already been generated, this script will just update your x509 proxy
 
 # Generate cert and key files (2 password prompts)
-if [ ! -f /opt/rucio/etc/client.crt ] || [ ! -f /opt/rucio/etc/client.key ]; then
-    openssl pkcs12 -in $1 -clcerts -nokeys -out /opt/rucio/etc/client.crt
-    openssl pkcs12 -in $1 -nocerts -nodes -out /opt/rucio/etc/client.key
-    chmod 0400 /opt/rucio/etc/client.crt
-    chmod 0400 /opt/rucio/etc/client.key
+if [[ ! -f /home/jovyan/client.crt ||  ! -f /home/jovyan/client.key ]]; then
+    openssl pkcs12 -in $1 -clcerts -nokeys -out /home/jovyan/client.crt
+    openssl pkcs12 -in $1 -nocerts -nodes -out /home/jovyan/client.key
+    chmod 0400 /home/jovyan/client.crt
+    chmod 0400 /home/jovyan/client.key
 fi
 # Generate short-lived x509 proxy (required for performing uploads to the data lake)
-voms-proxy-init --cert /opt/rucio/etc/client.crt --key /opt/rucio/etc/client.key --voms escape
+echo "Initializing the ESCAPE voms for your certificate"
+voms-proxy-init --cert /home/jovyan/client.crt --key /home/jovyan/client.key --voms escape
 
 # Set up Rucio config to point to the ESCAPE data lake with your account
 export RUCIO_CFG_ACCOUNT=$2

--- a/rucio-jupyterhub-container/etc/init.sh
+++ b/rucio-jupyterhub-container/etc/init.sh
@@ -2,4 +2,3 @@
 
 /rucio-jupyterlab/docker/configure.sh
 start-notebook.sh
-

--- a/rucio-jupyterhub-container/etc/rucio.cfg.j2
+++ b/rucio-jupyterhub-container/etc/rucio.cfg.j2
@@ -9,8 +9,8 @@ auth_type = {{ RUCIO_CFG_AUTH_TYPE | default('x509') }}
 username = {{ RUCIO_CFG_USERNAME | default('') }}
 password = {{ RUCIO_CFG_PASSWORD | default('') }}
 account = {{ RUCIO_CFG_ACCOUNT | default('') }}
-client_cert = {{ RUCIO_CFG_CLIENT_CERT | default('/opt/rucio/etc/client.crt') }}
-client_key = {{ RUCIO_CFG_CLIENT_KEY | default('/opt/rucio/etc/client.key') }}
+client_cert = {{ RUCIO_CFG_CLIENT_CERT | default('/home/jovyan/client.crt') }}
+client_key = {{ RUCIO_CFG_CLIENT_KEY | default('/home/jovyan/client.key') }}
 client_x509_proxy = {{ RUCIO_CFG_CLIENT_X509_PROXY | default('') }}
 request_retries = {{ RUCIO_CFG_REQUEST_RETRIES | default('3') }}
 


### PR DESCRIPTION
A few things have been modified:

1_ The Docker file of the rucio-jupyterhub-container was modified to activate the RUCIO autocompletion CLI. Also, the createProxyFromP12.sh file is executable inside the container.

2_ The path of the .crt and .key file were changed to /home/jovyan/ in the the createProxyFromP12.sh and the rucio.cfg.j2.