### PR TITLE
Updated README with another useful example

### DIFF
--- a/rucio-client-container/README.md
+++ b/rucio-client-container/README.md
@@ -24,6 +24,13 @@ $ make py3
 $ docker run -e RUCIO_CFG_ACCOUNT=<myrucioaccount> -v /path/to/client.crt:/opt/rucio/etc/client.crt -v /path/to/client.key:/opt/rucio/etc/client.key -it --name=rucio-client rucio-client
 ```
 
+### Using environment variables and a X.509 proxy
+
+```bash
+$ voms-proxy-init
+$ docker run -e RUCIO_CFG_ACCOUNT=<myrucioaccount> -e RUCIO_CFG_AUTH_TYPE=x509_proxy -e RUCIO_CFG_CLIENT_X509_PROXY=/opt/proxy/x509up_uNNNN -v /tmp:/opt/proxy -it --name=rucio-client rucio-client
+```
+
 ### Using a bespoke rucio.cfg
 
 ```bash 


### PR DESCRIPTION
Suggested another authentication method, based on a X.509 proxy obtained on the host node as opposed to the "root" X.509 credentials.