### PR TITLE
Add oidc settings to the config

### DIFF
--- a/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
+++ b/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
@@ -13,6 +13,7 @@ client_cert = {{ RUCIO_CFG_CLIENT_CERT | default('/opt/rucio/etc/client.crt') }}
 client_key = {{ RUCIO_CFG_CLIENT_KEY | default('/opt/rucio/etc/client.key') }}
 client_x509_proxy = {{ RUCIO_CFG_CLIENT_X509_PROXY | default('') }}
 request_retries = {{ RUCIO_CFG_REQUEST_RETRIES | default('3') }}
+oidc_issuer = {{ RUCIO_CFG_OIDC_ISSUER | default('https://iam-escape.cloud.cnaf.infn.it') }}
 
 [policy]
 permission = {{ RUCIO_CFG_POLICY_PERMISSION | default('generic')}}

--- a/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
+++ b/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
@@ -13,7 +13,7 @@ client_cert = {{ RUCIO_CFG_CLIENT_CERT | default('/opt/rucio/etc/client.crt') }}
 client_key = {{ RUCIO_CFG_CLIENT_KEY | default('/opt/rucio/etc/client.key') }}
 client_x509_proxy = {{ RUCIO_CFG_CLIENT_X509_PROXY | default('') }}
 request_retries = {{ RUCIO_CFG_REQUEST_RETRIES | default('3') }}
-oidc_issuer = {{ RUCIO_CFG_OIDC_ISSUER | default('https://iam-escape.cloud.cnaf.infn.it') }}
+oidc_issuer = {{ RUCIO_CFG_OIDC_ISSUER | default('escape') }}
 
 [policy]
 permission = {{ RUCIO_CFG_POLICY_PERMISSION | default('generic')}}


### PR DESCRIPTION
When trying to introduce someone to this container I realised the OIDC settings can't be set by the commands. Since we are looking into OIDC as a main protocol for AAI, this is probably something we want in the config by default.

Minor change but I'd like to have it reviewed anyway (sorry for first commiting to master, reverting and now committing again on branch)