### PR TITLE
Add polling to config

### DIFF
--- a/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
+++ b/rucio-client-container/etc/rucio/rucio.cfg.escape.j2
@@ -14,6 +14,7 @@ client_key = {{ RUCIO_CFG_CLIENT_KEY | default('/opt/rucio/etc/client.key') }}
 client_x509_proxy = {{ RUCIO_CFG_CLIENT_X509_PROXY | default('') }}
 request_retries = {{ RUCIO_CFG_REQUEST_RETRIES | default('3') }}
 oidc_issuer = {{ RUCIO_CFG_OIDC_ISSUER | default('escape') }}
+oidc_polling = {{ RUCIO_CFG_OIDC_POLLING | default('true') }}
 
 [policy]
 permission = {{ RUCIO_CFG_POLICY_PERMISSION | default('generic')}}


### PR DESCRIPTION
I added polling to the config, that makes the login flow to OIDC smoother (and since the timeout is already quite strict, it may be more useful to have something automated)