### PR TITLE
access egi using https

### DIFF
--- a/rucio-client-container/Dockerfile
+++ b/rucio-client-container/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASEIMAGE:$BASETAG
 USER root
 
 # EGI trust anchors
-RUN curl -o /etc/yum.repos.d/EGI-trustanchors.repo http://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo \
+RUN curl -o /etc/yum.repos.d/EGI-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo \
     && yum -y update
 
 RUN yum -y install wget


### PR DESCRIPTION
The currrent action is broken, this is due to the fact that we try to download a file from the EGI http domain. It seems like they stopped supporting http and moved to https. So this is a single-letter pull request :) 